### PR TITLE
fix TopAnimeFilter["filter"] enum

### DIFF
--- a/src/manager/anime.ts
+++ b/src/manager/anime.ts
@@ -51,7 +51,7 @@ export interface AnimeSearchFilter {
 
 export interface TopAnimeFilter {
   type: 'tv' | 'movie' | 'ova' | 'special' | 'ona' | 'music'
-  filter: 'publishing' | 'upcoming' | 'bypopularity' | 'favorite'
+  filter: 'airing' | 'upcoming' | 'bypopularity' | 'favorite'
 }
 
 export class AnimeManager extends BaseManager {


### PR DESCRIPTION
replace "publishing" with "airing" in TopAnimeFilter["filter"]

See https://docs.api.jikan.moe/#tag/top/operation/getTopAnime for the correct filter enums