### PR TITLE
Fixed api queue for duplicate requests

### DIFF
--- a/dist/core/api.js
+++ b/dist/core/api.js
@@ -105,11 +105,11 @@ class APIClient {
                         const responseData = yield this.execReqeust(requestData);
                         for (let queueIndex = 0; queue.length > queueIndex; queueIndex++) {
                             const otherEntry = queue[queueIndex];
-                            const { requestData: { path: otherPath, query: otherQuery } } = otherEntry;
+                            const { requestData: { path: otherPath, cache: otherCache, query: otherQuery }, resolve: otherResolve } = otherEntry;
                             const { path, query } = requestData;
-                            if (JSON.stringify([otherPath, otherQuery]) === JSON.stringify([path, query])) {
+                            if (otherCache && JSON.stringify([otherPath, otherQuery]) === JSON.stringify([path, query])) {
                                 queue.splice(queueIndex--, 1);
-                                resolve(responseData);
+                                otherResolve(responseData);
                             }
                         }
                         resolve(responseData);

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -171,13 +171,13 @@ export class APIClient {
           const responseData = await this.execReqeust(requestData)
           for (let queueIndex = 0; queue.length > queueIndex; queueIndex++) {
             const otherEntry = queue[queueIndex]
-            const { requestData: { path: otherPath, query: otherQuery } } = otherEntry
+            const { requestData: { path: otherPath, cache: otherCache, query: otherQuery }, resolve: otherResolve } = otherEntry
             const { path, query } = requestData
 
-            if (JSON.stringify([otherPath, otherQuery]) === JSON.stringify([path, query])) {
+            if (otherCache && JSON.stringify([otherPath, otherQuery]) === JSON.stringify([path, query])) {
               queue.splice(queueIndex--, 1)
 
-              resolve(responseData)
+              otherResolve(responseData)
             }
           }
 


### PR DESCRIPTION
There are two issues with the api queue (one may be subjective). The expected behavior when there are multiple rapid api requests, is that they are placed with a queue array. They are one by one executed to comply with the Jikan rate limit. If there are duplicate requests within the queue, and one of the duplicate request complete, all duplicate requests are removed from the queue. However there is an issue:

1. When the duplicate requests are removed from the queue, the duplicate's Promise `resolve` is not called. Eg, if I call `characters.listTop()` three times within a second, Only the first call succeeds. The last two calls never returns their promise.

2. This fix may be subjective, but the duplicate request removal should not apply to any `/random/*` calls. For example, if I call `characters.random()` three times within a second, it returns the same character for all three of these calls. IMO it should return different characters per request. To fix this, I ignored the duplicate request removal if disableCache is true (All random api calls have caches disabled).